### PR TITLE
Logging

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# v0.1.2 / 2022-08-10
+
+## Enhancements
+
+* Enable logging for twirp request events
+
 # v0.1.1 / 2019-04-27
 
 ## Enhancements

--- a/README.md
+++ b/README.md
@@ -81,6 +81,20 @@ Prefix Verb URI Pattern                           Controller#Action
             /twirp/HelloService/Hi                hello
 ```
 
+### Logging
+
+If you want to log the twirp requests pass the logger to the initializer.  
+For example:
+
+```ruby
+# config/initializers/twirp_rails.rb
+
+Twirp::Rails.configuration do |c|
+  # ...other configs...
+  c.logger = Rails.logger
+end
+```
+
 ## Development
 
 After checking out the repo, run `bin/setup` to install dependencies. Then, run `rake spec` to run the tests. You can also run `bin/console` for an interactive prompt that will allow you to experiment.

--- a/lib/twirp/rails.rb
+++ b/lib/twirp/rails.rb
@@ -4,6 +4,7 @@ require "twirp/rails/configuration"
 require "twirp/rails/helpers"
 require "twirp/rails/routes"
 require "twirp/rails/engine"
+require "twirp/rails/events_callbacks"
 require "twirp/rails/events_logger"
 require "twirp/rails/version"
 
@@ -27,11 +28,8 @@ module Twirp
         Dir[File.join(configuration.handlers_path.to_s, '**', '*.rb')].each { |f| require f }
       end
 
-      def create_events_logger
-        return unless configuration.logger.present?
-
-        event_logger = Twirp::Rails::EventsLogger.new(::Rails.logger)
-        Twirp::Rails.services.each { |s| event_logger.register(s) }
+      def register_callbacks
+        Twirp::Rails.services.each { |s| Twirp::Rails::EventsCallbacks.register(s) }
       end
     end
   end

--- a/lib/twirp/rails.rb
+++ b/lib/twirp/rails.rb
@@ -29,6 +29,9 @@ module Twirp
       end
 
       def register_callbacks
+        # as for now, the only callbacks are for logging, we can skip it if logger was not set
+        return if Twirp::Rails::EventsLogger.logger.nil?
+
         Twirp::Rails.services.each { |s| Twirp::Rails::EventsCallbacks.register(s) }
       end
     end

--- a/lib/twirp/rails.rb
+++ b/lib/twirp/rails.rb
@@ -4,6 +4,7 @@ require "twirp/rails/configuration"
 require "twirp/rails/helpers"
 require "twirp/rails/routes"
 require "twirp/rails/engine"
+require "twirp/rails/events_logger"
 require "twirp/rails/version"
 
 module Twirp
@@ -24,6 +25,13 @@ module Twirp
 
       def load_handlers
         Dir[File.join(configuration.handlers_path.to_s, '**', '*.rb')].each { |f| require f }
+      end
+
+      def create_events_logger
+        return unless configuration.logger.present?
+
+        event_logger = Twirp::Rails::EventsLogger.new(::Rails.logger)
+        Twirp::Rails.services.each { |s| event_logger.register(s) }
       end
     end
   end

--- a/lib/twirp/rails/configuration.rb
+++ b/lib/twirp/rails/configuration.rb
@@ -4,6 +4,7 @@ module Twirp
   module Rails
     class Configuration
       attr_reader :handlers_path
+      attr_accessor :logger
 
       def initialize
         @handlers_path = nil

--- a/lib/twirp/rails/engine.rb
+++ b/lib/twirp/rails/engine.rb
@@ -7,7 +7,7 @@ module Twirp
     class Engine < ::Rails::Engine
       initializer "twirp.rails.routes" do
         Twirp::Rails.load_handlers
-        Twirp::Rails.create_events_logger
+        Twirp::Rails.register_callbacks
         Twirp::Rails::Routes.install!
       end
     end

--- a/lib/twirp/rails/engine.rb
+++ b/lib/twirp/rails/engine.rb
@@ -7,6 +7,7 @@ module Twirp
     class Engine < ::Rails::Engine
       initializer "twirp.rails.routes" do
         Twirp::Rails.load_handlers
+        Twirp::Rails.create_events_logger
         Twirp::Rails::Routes.install!
       end
     end

--- a/lib/twirp/rails/events_callbacks.rb
+++ b/lib/twirp/rails/events_callbacks.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+module Twirp
+  module Rails
+    class EventsCallbacks
+      def self.register(service)
+        service.before do |rack_env, env| 
+          env[:request_start_time] = Time.now
+          EventsLogger.log_before_event(rack_env, env) if EventsLogger.logger.present?
+        end
+
+        service.on_success do |env| 
+          register_event_duration(env)
+          EventsLogger.log_on_success_event(env) if EventsLogger.logger.present?
+        end
+
+        service.on_error do |twerr, env| 
+          register_event_duration(env)
+          EventsLogger.log_on_error_event(twerr, env) if EventsLogger.logger.present?
+        end
+
+        service.exception_raised do |e, env| 
+          EventsLogger.log_exception_raised_event(e, env) if EventsLogger.logger.present?
+        end
+      end
+
+      private_instance_methods
+
+      def self.register_event_duration(env)
+        request_start_time = env[:request_start_time]
+        return -1 unless request_start_time
+
+        env[:event_duration] = ((Time.now - request_start_time) * 1000).to_i
+      end
+    end
+  end
+end

--- a/lib/twirp/rails/events_logger.rb
+++ b/lib/twirp/rails/events_logger.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+
+module Twirp
+  module Rails
+    class EventsLogger
+      def initialize(logger)
+        @logger = logger
+      end
+
+      def register(service)
+        service.before { |*args| log_before_event(*args) }
+        service.on_success { |*args| log_on_success_event(*args) }
+        service.on_error { |*args| log_on_error_event(*args) }
+        service.exception_raised { |*args| log_exception_raised_event(*args) }
+      end
+
+      private
+
+      def log_before_event(rack_env, env)
+        params = env[:input].to_h
+        env[:request_start_time] = Time.now
+
+        @logger.info "Starting handler for twirp request #{env[:input_class]}##{env[:ruby_method]}"
+        @logger.info " Parameters: #{params.inspect}" unless params.empty?
+      end
+
+      def log_on_success_event(env)
+        @logger.info "Completed with success in #{event_duration(env)}ms"
+      end
+
+      def log_on_error_event(twerr, env)
+        @logger.info "Completed with error in #{event_duration(env)}ms #{twerr}"
+      end
+
+      def log_exception_raised_event(e, env)
+        @logger.error "[Exception] #{e.class}:#{e.message}\n#{e.backtrace.join("\n")}"
+      end
+
+      def event_duration(env)
+        request_start_time = env[:request_start_time]
+        return -1 unless request_start_time
+
+        ((Time.now - request_start_time) * 1000).to_i
+      end
+    end
+  end
+end

--- a/lib/twirp/rails/events_logger.rb
+++ b/lib/twirp/rails/events_logger.rb
@@ -1,46 +1,29 @@
 # frozen_string_literal: true
-
 module Twirp
   module Rails
     class EventsLogger
-      def initialize(logger)
-        @logger = logger
+      def self.logger
+        Twirp::Rails.configuration.logger
       end
 
-      def register(service)
-        service.before { |*args| log_before_event(*args) }
-        service.on_success { |*args| log_on_success_event(*args) }
-        service.on_error { |*args| log_on_error_event(*args) }
-        service.exception_raised { |*args| log_exception_raised_event(*args) }
-      end
-
-      private
-
-      def log_before_event(rack_env, env)
+      def self.log_before_event(rack_env, env)
         params = env[:input].to_h
         env[:request_start_time] = Time.now
 
-        @logger.info "Starting handler for twirp request #{env[:input_class]}##{env[:ruby_method]}"
-        @logger.info " Parameters: #{params.inspect}" unless params.empty?
+        logger.info "Starting handler for twirp request #{env[:input_class]}##{env[:ruby_method]}"
+        logger.info " Parameters: #{params.inspect}" unless params.empty?
       end
 
-      def log_on_success_event(env)
-        @logger.info "Completed with success in #{event_duration(env)}ms"
+      def self.log_on_success_event(env)
+        logger.info "Completed with success in #{env[:event_duration]}ms"
       end
 
-      def log_on_error_event(twerr, env)
-        @logger.info "Completed with error in #{event_duration(env)}ms #{twerr}"
+      def self.log_on_error_event(twerr, env)
+        logger.info "Completed with error in #{env[:event_duration]}ms #{twerr}"
       end
 
-      def log_exception_raised_event(e, env)
-        @logger.error "[Exception] #{e.class}:#{e.message}\n#{e.backtrace.join("\n")}"
-      end
-
-      def event_duration(env)
-        request_start_time = env[:request_start_time]
-        return -1 unless request_start_time
-
-        ((Time.now - request_start_time) * 1000).to_i
+      def self.log_exception_raised_event(e, env)
+        logger.error "[Exception] #{e.class}:#{e.message}\n#{e.backtrace.join("\n")}"
       end
     end
   end

--- a/lib/twirp/rails/version.rb
+++ b/lib/twirp/rails/version.rb
@@ -1,5 +1,5 @@
 module Twirp
   module Rails
-    VERSION = "0.1.1"
+    VERSION = "0.1.2"
   end
 end

--- a/spec/twirp/rails/events_callbacks_spec.rb
+++ b/spec/twirp/rails/events_callbacks_spec.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe Twirp::Rails::EventsCallbacks do
+  describe '#register' do
+    let(:service) { Twirp::Service.new(Object.new) }
+    it 'register callback for before event' do
+      expect { described_class.register(service) }.to change { service.instance_variable_get(:@before).length }.by(1)
+    end
+
+    it 'register callback for on_success event' do
+      expect { described_class.register(service) }.to change { service.instance_variable_get(:@on_success).length }.by(1)
+    end
+
+    it 'register callback for on_error event' do
+      expect { described_class.register(service) }.to change { service.instance_variable_get(:@on_error).length }.by(1)
+    end
+
+    it 'register callback for exception_raised event' do
+      expect { described_class.register(service) }.to change { service.instance_variable_get(:@exception_raised).length }.by(1)
+    end
+  end
+end

--- a/spec/twirp/rails/events_logger_spec.rb
+++ b/spec/twirp/rails/events_logger_spec.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe Twirp::Rails::EventsLogger do
+  let(:logger) { spy }
+
+  before do
+    allow(described_class).to receive(:logger).and_return(logger)
+  end
+
+  describe '.log_before_event' do
+    it 'log the message' do 
+      described_class.log_before_event({}, {})
+      expect(logger).to have_received(:info)
+    end
+  end
+
+  describe '.log_on_success_event' do
+    it 'log the message' do 
+      described_class.log_on_success_event({})
+      expect(logger).to have_received(:info)
+    end
+  end
+
+  describe '.log_on_error_event' do
+    it 'log the message' do 
+      described_class.log_on_error_event({}, {})
+      expect(logger).to have_received(:info)
+    end
+  end
+
+  describe '.log_exception_raised_event' do
+    it 'log the message' do 
+      described_class.log_exception_raised_event(spy, {})
+      expect(logger).to have_received(:error)
+    end
+  end
+end


### PR DESCRIPTION
## Summary

This PR enables logging for Twirp requests, for example

For a successful request
```
Started POST "/twirp/xxx.yyy.ResourceApi/CreateResources" for 127.0.0.1 at 2022-08-10 23:32:57 +0900
Starting handler for twirp request Xxx::Yyy::CreateResourcesRequest#create_resources
 Parameters: {:names=>["hogehoge", "fugafuga"]}
Completed with success in 0ms
```

For a request that throw some error
```
Started POST "/twirp/xxx.yyy.ResourceApi/CreateResources" for 127.0.0.1 at 2022-08-10 23:32:57 +0900
Starting handler for twirp request Xxx::Yyy::CreateResourcesRequest#create_resources
 Parameters: {:names=>["hogehoge", "fugafuga"]}
[Exception] StandardError:StandardError
/.../Projects/twirp-playground/app/controllers/api/resource_controller.rb:6:in `create_resources'
/.../gems/2.7.0/gems/twirp-1.7.0/lib/twirp/service.rb:165:in `call_handler'
/.../gems/2.7.0/gems/twirp-1.7.0/lib/twirp/service.rb:72:in `call'
/.../gems/2.7.0/gems/actionpack-7.0.3.1/lib/action_dispatch/routing/mapper.rb:19:in `block in <class:Constraints>'
/.../gems/2.7.0/gems/actionpack-7.0.3.1/lib/action_dispatch/routing/mapper.rb:48:in `serve'
/.../gems/2.7.0/gems/actionpack-7.0.3.1/lib/action_dispatch/journey/router.rb:50:in `block in serve'
/.../gems/2.7.0/gems/actionpack-7.0.3.1/lib/action_dispatch/journey/router.rb:32:in `each'
/.../gems/2.7.0/gems/actionpack-7.0.3.1/lib/action_dispatch/journey/router.rb:32:in `serve'
...
```

## Motivation

Currently we don't have logs for twirp request, it makes debugging a little bit complicated.

## About the implementation

I'm not sure if it is the best way, or if we should use something more Rails like, using Instrument and LogSubscriber.